### PR TITLE
Fix: ':shadow' selector removed

### DIFF
--- a/styles/editing-diff.less
+++ b/styles/editing-diff.less
@@ -2,8 +2,7 @@
 @import "octicon-utf-codes";
 @import "octicon-mixins";
 
-atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor {
   .gutter .line-number {
     &.editing-line-modified {
       border-left: 2px solid @syntax-color-modified;


### PR DESCRIPTION
Since it deprecated for atom 1.13 and higher.
Not sure that is the correct solution, but it works in my case and no issues were raised.